### PR TITLE
feat: lazy loading, unique index in Email and migration

### DIFF
--- a/dao_library/Migrations/20250928034424_AddUserEmailUniqueIndex.Designer.cs
+++ b/dao_library/Migrations/20250928034424_AddUserEmailUniqueIndex.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using dao_library.Contexts;
 
@@ -10,9 +11,11 @@ using dao_library.Contexts;
 namespace dao_library.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250928034424_AddUserEmailUniqueIndex")]
+    partial class AddUserEmailUniqueIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dao_library/Migrations/20250928034424_AddUserEmailUniqueIndex.cs
+++ b/dao_library/Migrations/20250928034424_AddUserEmailUniqueIndex.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace dao_library.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserEmailUniqueIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "Users",
+                type: "varchar(191)",
+                maxLength: 191,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "longtext")
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_Email",
+                table: "Users",
+                column: "Email",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Users_Email",
+                table: "Users");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "Users",
+                type: "longtext",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(191)",
+                oldMaxLength: 191)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/dao_library/entity_framework/AppDbContext.cs
+++ b/dao_library/entity_framework/AppDbContext.cs
@@ -2,9 +2,10 @@ using Microsoft.EntityFrameworkCore;
 using entity_library.system;
 namespace dao_library.Contexts;
 
+
 public class AppDbContext : DbContext
 {
-    public AppDbContext(DbContextOptions options) : base(options)
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
     {
     }
 
@@ -17,6 +18,20 @@ public class AppDbContext : DbContext
     public DbSet<Like> Likes { get; set; }
     public DbSet<Post> Posts { get; set; }
     public DbSet<User> Users { get; set; }
+
     public DbSet<Role> Roles { get; set; }
-    
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        // Unique index for Email in User y limitar longitud a 191 caracteres (MySQL utf8mb4)
+        modelBuilder.Entity<User>()
+            .HasIndex(u => u.Email)
+            .IsUnique();
+        modelBuilder.Entity<User>()
+            .Property(u => u.Email)
+            .HasMaxLength(191)
+            .IsRequired();
+    }
 }


### PR DESCRIPTION
Enable EF Core Lazy Loading, add unique index to User Email, and apply migration. Ensures navigation properties are loaded automatically and prevents duplicate user emails at the database level.